### PR TITLE
feat: add local event listeners, fire event when downloaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,16 +21,17 @@ Button to trigger the download of the pdf must emit a custom event and pass on t
 Function that will emit the custom event:
 
     function downloadPdf(filename = 'no-file-name-provided') {
-        const event = new CustomEvent("download-pdf", {
-          composed: true,
-          bubbles: true,
-          detail: {
-            fileName: filename,
-          },
-        });
-        const obj = document.getElementById("print-pdf");
-        obj.dispatchEvent(event);
+      const event = new CustomEvent("download-pdf", {
+        composed: true,
+        bubbles: true,
+        detail: {
+          fileName: filename,
+        },
+      });
+      document.getElementById('pdfComponent').shadowRoot.dispatchEvent(event);
     }
+
+    This part: document.getElementById('pdfComponent') can be replaced with the any access way to the component(id, class...) that contain the shadowRoot.
 
 ## Apply styles to the Web Component
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -31,12 +31,11 @@
             fileName: filename,
           },
         });
-        const obj = document.getElementById("print-pdf");
-        obj.dispatchEvent(event);
+        document.getElementById('pdfComponent').shadowRoot.dispatchEvent(event);
       }
     </script>
     <button id="print-pdf" onclick="downloadPdf('filename-requested')">Download Pdf</button>
-    <print-to-pdf html="<p>Test</p>"></print-to-pdf>
+    <print-to-pdf id="pdfComponent" html="<p>Test</p>"></print-to-pdf>
   </body>
 </html>
 

--- a/export/pdf-component.js
+++ b/export/pdf-component.js
@@ -44,25 +44,30 @@ class PrintToPdf extends LitElement {
   }
 
   __scrollTop() {
-    const e = this.shadowRoot.querySelector('#element-to-print');
-    e.scrollTop = 0;
+    const element = this.shadowRoot.querySelector('#element-to-print');
+    element.scrollTop = 0;
   }
 
   __downloadPdf(event) {
     const elementToPrint = this.shadowRoot.querySelector('#element-to-print');
     if (!elementToPrint) {
       console.warn('The web component has not rendered yet, retrying in 100ms');
-      setTimeout( ()=>this.__downloadPdf(event), 100);
+      setTimeout( () => this.__downloadPdf(event), 100);
       return
     }
     try {
-    html2pdf().set({html2canvas: {scrollX: 0, scrollY:0}}).from(elementToPrint).save(event.detail?.fileName || 'file.pdf').then(()=>{
+      html2pdf().set({
+        html2canvas: {
+          scrollX: 0,
+          scrollY:0
+        }
+      }).from(elementToPrint).save(event.detail?.fileName || 'file.pdf').then(() => {
         const downloadedEvent = new Event('downloaded');
         this.dispatchEvent(downloadedEvent);
       });
     }
     catch(error) {
-      console.log(error);
+      throw new Error(error);
     }
   }
 


### PR DESCRIPTION
This commit:
- Hook the listeners to the component itself instead of window (!!)
- Introduce an event listener we can use to scroll to the top the
  content of the HTML preview
- Dispatch an 'updated' event every time the html changes and the
  content rerenders
- Dispatch a 'download' event when html2pdf has completed the conversion
  and the file is on the way to the browser
- Add setting to html2pdf to render content starting from the top