### PR TITLE
fix: fix when user only have one pdf to download

### DIFF
--- a/export/pdf-component.js
+++ b/export/pdf-component.js
@@ -15,10 +15,11 @@ class PrintToPdf extends HTMLElement {
   }
 
   connectedCallback() {
+    this.shadowRoot.addEventListener('download-pdf', this._downloadPdf);
+
     if(this.isRendered) return;
 
     this.isRendered = true;
-    this.shadowRoot.addEventListener('download-pdf', this._downloadPdf);
 
     this.shadowRoot.addEventListener('scrollTop', this._scrollTop);
 


### PR DESCRIPTION
## How?

Add the download event before check the render so we avoid to miss the download.

## Testing?

#### E2E: 
E2E cases tested
#### Unit:
Unit cases tested
