### PR TITLE
chore(eslint): add missing eslint rules and env

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,11 +2,274 @@ module.exports = {
   root: true,
   parser: 'babel-eslint',
   env: {
+    es6: true,
     browser: true,
     node: false
   },
-  plugins: ["sonarjs"],
+  plugins: ['sonarjs'],
   extends: [
     'plugin:sonarjs/recommended'
   ],
-}
+  rules: {
+    'quotes': [
+      'warn',
+      'single', {'avoidEscape': true}
+    ],
+    'comma-dangle': [
+      'error',
+      'never'
+    ],
+    'no-cond-assign': [
+      'error',
+      'except-parens'
+    ],
+    'no-console': 'off',
+    'no-constant-condition': 'error',
+    'no-control-regex': 'error',
+    'no-debugger': 'error',
+    'no-dupe-args': 'error',
+    'no-dupe-keys': 'error',
+    'no-duplicate-case': 'error',
+    'no-empty-character-class': 'error',
+    'no-empty': 'error',
+    'no-ex-assign': 'error',
+    'no-extra-boolean-cast': 'off',
+    'no-extra-semi': 'error',
+    'no-func-assign': 'error',
+    'no-inner-declarations': [
+      'error',
+      'both'
+    ],
+    'no-invalid-regexp': 'error',
+    'no-irregular-whitespace': 'error',
+    'no-obj-calls': 'error',
+    'no-regex-spaces': 'error',
+    'no-sparse-arrays': 'error',
+    'no-unexpected-multiline': 'error',
+    'no-unreachable': 'error',
+    'no-unsafe-negation': 'error',
+    'space-in-parens': [
+      2,
+      'never'
+    ],
+    'use-isnan': 'error',
+    'valid-jsdoc': 'error',
+    'valid-typeof': 'error',
+    'block-scoped-var': 'error',
+    'curly': 'error',
+    'default-case': 'error',
+    'dot-location': [
+      'error',
+      'property'
+    ],
+    'dot-notation': [
+      'error',
+      {
+        'allowPattern': '^[a-z]+(([0-9]+)|(_[a-z]+)|([A-Z][a-z]+[0-9]*))+$'
+      }
+    ],
+    'eqeqeq': 'error',
+    'guard-for-in': 'error',
+    'no-alert': 'error',
+    'no-caller': 'error',
+    'no-case-declarations': 'error',
+    'no-empty-function': 'warn',
+    'no-empty-pattern': 'error',
+    'no-eq-null': 'error',
+    'no-eval': 'error',
+    'no-extend-native': 'error',
+    'no-extra-bind': 'error',
+    'no-fallthrough': 'error',
+    'no-global-assign': 'error',
+    'no-implicit-globals': 'error',
+    'no-implied-eval': 'error',
+    'no-invalid-this': 'off',
+    'no-iterator': 'error',
+    'no-labels': 'error',
+    'no-lone-blocks': 'error',
+    'no-loop-func': 'error',
+    'no-magic-numbers': [
+      'off',
+      {
+        'ignoreArrayIndexes': true,
+        'ignore': [
+          -1,
+          0,
+          1
+        ]
+      }
+    ],
+    'no-multi-spaces': 'error',
+    'no-multi-str': 'error',
+    'no-new-func': 'error',
+    'no-new-wrappers': 'error',
+    'no-new': 'error',
+    'no-octal-escape': 'error',
+    'no-octal': 'error',
+    'no-param-reassign': [
+      'error',
+      {
+        'props': false
+      }
+    ],
+    'no-process-env': 'off',
+    'no-proto': 'error',
+    'no-redeclare': 'error',
+    'no-return-assign': 'error',
+    'no-script-url': 'error',
+    'no-self-compare': 'error',
+    'no-throw-literal': 'error',
+    'no-unused-expressions': [
+      'error',
+      {
+        'allowShortCircuit': true
+      }
+    ],
+    'no-useless-call': 'error',
+    'no-useless-concat': 'error',
+    'no-void': 'error',
+    'no-warning-comments': [
+      'off',
+      {
+        'terms': [
+          'todo',
+          'fixme'
+        ],
+        'location': 'start'
+      }
+    ],
+    'no-with': 'error',
+    'radix': 'error',
+    'vars-on-top': 'error',
+    'wrap-iife': [
+      'error',
+      'outside'
+    ],
+    'yoda': 'error',
+    'strict': 'error',
+    'no-delete-var': 'error',
+    'no-label-var': 'error',
+    'no-shadow-restricted-names': 'error',
+    'no-shadow': 'off',
+    'no-undef': 'warn',
+    'no-unused-vars': 'warn',
+    'no-use-before-define': [
+      'error',
+      {
+        'functions': true,
+        'classes': true
+      }
+    ],
+    'block-spacing': 'error',
+    'brace-style': [
+      'error',
+      'stroustrup',
+      {
+        'allowSingleLine': true
+      }
+    ],
+    'comma-spacing': [
+      'error'
+    ],
+    'comma-style': [
+      'error',
+      'last'
+    ],
+    'consistent-this': 'off',
+    'computed-property-spacing': [
+      'error',
+      'never'
+    ],
+    'eol-last': 'error',
+    'indent': [
+      'error',
+      2
+    ],
+    'keyword-spacing': [
+      'error',
+      {
+        'before': true,
+        'after': true
+      }
+    ],
+    'linebreak-style': [
+      'error',
+      'unix'
+    ],
+    'max-depth': [
+      'error'
+    ],
+    'max-params': [
+      'error',
+      9
+    ],
+    'max-statements': [
+      'error',
+      40,
+      {
+        'ignoreTopLevelFunctions': true
+      }
+    ],
+    'new-cap': 'error',
+    'new-parens': 'error',
+    'no-array-constructor': 'error',
+    'no-bitwise': 'error',
+    'no-mixed-spaces-and-tabs': 'error',
+    'no-multiple-empty-lines': [
+      'error',
+      {
+        'max': 2
+      }
+    ],
+    'no-nested-ternary': 'error',
+    'no-new-object': 'error',
+    'no-spaced-func': 'error',
+    'no-trailing-spaces': 'error',
+    'no-unneeded-ternary': 'error',
+    'no-whitespace-before-property': 'error',
+    'object-curly-spacing': [
+      'error',
+      'never'
+    ],
+    'object-shorthand': 'warn',
+    'quote-props': [
+      'error',
+      'as-needed',
+      {
+        'keywords': false,
+        'unnecessary': false
+      }
+    ],
+    'require-atomic-updates': 'warn',
+    'require-await': 'warn',
+    'semi': ['error', 'always'],
+    'semi-spacing': [
+      'error',
+      {
+        'before': false,
+        'after': true
+      }
+    ],
+    'space-unary-ops': [
+      'error',
+      {
+        'words': true,
+        'nonwords': false
+      }
+    ],
+    'spaced-comment': [
+      'error',
+      'always',
+      {
+        'block': {
+          'balanced': true
+        }
+      }
+    ],
+    'wrap-regex': 'error',
+    'sonarjs/no-duplicate-string': 'off',
+    'sonarjs/prefer-immediate-return': 'off',
+    'sonarjs/cognitive-complexity': ['error', 40],
+    'object-property-newline': ['warn', {'allowAllPropertiesOnSameLine': false}]
+  }
+};

--- a/export/pdf-component.js
+++ b/export/pdf-component.js
@@ -17,13 +17,13 @@ class PrintToPdf extends HTMLElement {
   connectedCallback() {
     this.shadowRoot.addEventListener('download-pdf', this._downloadPdf);
 
-    if(this.isRendered) return;
+    if (this.isRendered) { return; }
 
     this.isRendered = true;
 
     this.shadowRoot.addEventListener('scrollTop', this._scrollTop);
 
-    this.html = this.getAttribute('html') || "<p>No content passed</p>";
+    this.html = this.getAttribute('html') || '<p>No content passed</p>';
 
     this.shadowRootStyle = this.getAttribute('style') || `
     :host {
@@ -47,16 +47,16 @@ class PrintToPdf extends HTMLElement {
       composed: true
     });
     this.shadowRoot.dispatchEvent(event);
-  };
+  }
 
   _printPdf() {
     window.print();
-  };
+  }
 
   _scrollTop() {
     const element = this.shadowRoot.querySelector('#element-to-print');
     element.scrollTop = 0;
-  };
+  }
 
   _downloadPdf(event) {
     const elementToPrint = this.shadowRoot.querySelector('#element-to-print');
@@ -66,7 +66,7 @@ class PrintToPdf extends HTMLElement {
     const isApple = navigator.vendor.match(/apple/i);
 
     // Firefox does not support a canvas size as big as chrome
-    const isFirefox = navigator.userAgent.match(/firefox/i)
+    const isFirefox = navigator.userAgent.match(/firefox/i);
 
     // Do not abuse, higher values are glitchy and images may disappear or the
     // file may fail to render altogether
@@ -80,21 +80,21 @@ class PrintToPdf extends HTMLElement {
 
     if (!elementToPrint) {
       console.warn('The web component has not rendered yet, retrying in 100ms');
-      setTimeout( () => this._downloadPdf(event), 100);
-      return
+      setTimeout(() => this._downloadPdf(event), 100);
+      return;
     }
     try {
       const options = {
         image: {
-            type: 'jpeg',
-            quality: 0.75
-          },
-          html2canvas: {
-            scrollX: 0,
-            scrollY: 0,
-            scale: scale
-          }
-      }
+          type: 'jpeg',
+          quality: 0.75
+        },
+        html2canvas: {
+          scrollX: 0,
+          scrollY: 0,
+          scale
+        }
+      };
       html2pdf()
         .set(options)
         .from(elementToPrint)
@@ -105,10 +105,10 @@ class PrintToPdf extends HTMLElement {
           this.dispatchEvent(downloadedEvent);
         });
     }
-    catch(error) {
+    catch (error) {
       throw new Error(error);
     }
-  };
+  }
 
   _render() {
     const wrapperElement = document.createElement('div');

--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
-import PrintToPdf from "./export/pdf-component.js";
+import PrintToPdf from './export/pdf-component.js';
 
-export {PrintToPdf}
+export {PrintToPdf};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,8 +4,8 @@ module.exports = {
   mode: 'production',
   entry: './index.js',
   output: {
-    path: path.resolve(__dirname, "dist"),
-    filename: 'index.js',
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'index.js'
   },
   module: {
     rules: [
@@ -13,9 +13,9 @@ module.exports = {
         test: /\.js$/,
         exclude: /(node_modules)/,
         use: {
-          loader: "babel-loader",
+          loader: 'babel-loader',
           options: {
-            presets: ["@babel/preset-env"]
+            presets: ['@babel/preset-env']
           }
         }
       }


### PR DESCRIPTION
# Ticket https://tignum.atlassian.net/browse/WEBDEV-2597

## How?

The eslint configuration is missing our common set of rules, this change allows the editor to do the automatic formatting following our style guide

## Testing?

#### E2E:
E2E cases tested: Nope
#### Unit:
Unit cases tested: Nope